### PR TITLE
#35198: Log metrics for apps launched outside of registered command framework

### DIFF
--- a/python/tk_houdini_mantranode/handler.py
+++ b/python/tk_houdini_mantranode/handler.py
@@ -498,6 +498,15 @@ class TkMantraNodeHandler(object):
         # make sure the render paths are in default state
         self.reset_render_path(node)
 
+        try:
+            self._app.log_metric("Create")
+            self._app.engine.log_user_attribute_metric(
+                "%s version" % (self._app.name,),
+                self._app.version,
+            )
+        except:
+            # ingore any errors. ex: metrics logging not supported
+            pass
 
     def update_parms(self, node=None):
         """Update a set of predefined parameters as the render path changes.

--- a/python/tk_houdini_mantranode/handler.py
+++ b/python/tk_houdini_mantranode/handler.py
@@ -499,11 +499,7 @@ class TkMantraNodeHandler(object):
         self.reset_render_path(node)
 
         try:
-            self._app.log_metric("Create")
-            self._app.engine.log_user_attribute_metric(
-                "%s version" % (self._app.name,),
-                self._app.version,
-            )
+            self._app.log_metric("Create", log_version=True)
         except:
             # ingore any errors. ex: metrics logging not supported
             pass


### PR DESCRIPTION
This change logs the app version and one action metric for "create".
