### PR TITLE
#44077 Adds app-level methods to query nodes and output path

### DIFF
--- a/app.py
+++ b/app.py
@@ -105,3 +105,9 @@ class TkMantraNodeApp(sgtk.platform.Application):
         self.log_debug("Retrieved output path: %s" % (output_path,))
         return output_path
 
+    def get_work_file_template(self):
+        """
+        Returns the configured work file template for the app.
+        """
+
+        return self.get_template("work_file_template")

--- a/app.py
+++ b/app.py
@@ -67,4 +67,41 @@ class TkMantraNodeApp(sgtk.platform.Application):
         tk_houdini_mantra.TkMantraNodeHandler.\
             convert_back_to_tk_mantra_nodes(self)
 
+    def get_nodes(self):
+        """
+        Returns a list of hou.node objects for each tk mantra node.
+
+        Example usage::
+
+        >>> import sgtk
+        >>> eng = sgtk.platform.current_engine()
+        >>> app = eng.apps["tk-houdini-mantranode"]
+        >>> tk_mantra_nodes = app.get_nodes()
+        """
+
+        self.log_debug("Retrieving tk-houdini-mantra nodes...")
+        tk_houdini_mantra = self.import_module("tk_houdini_mantranode")
+        nodes = tk_houdini_mantra.TkMantraNodeHandler.\
+            get_all_tk_mantra_nodes()
+        self.log_debug("Found %s tk-houdini-mantra nodes." % (len(nodes),))
+        return nodes
+
+    def get_output_path(self, node):
+        """
+        Returns the evaluated output path for the supplied node.
+
+        Example usage::
+
+        >>> import sgtk
+        >>> eng = sgtk.platform.current_engine()
+        >>> app = eng.apps["tk-houdini-mantranode"]
+        >>> output_path = app.get_output_path(tk_mantra_node)
+        """
+
+        self.log_debug("Retrieving output path for %s" % (node,))
+        tk_houdini_mantra = self.import_module("tk_houdini_mantranode")
+        output_path = tk_houdini_mantra.TkMantraNodeHandler.\
+            get_output_path(node)
+        self.log_debug("Retrieved output path: %s" % (output_path,))
+        return output_path
 

--- a/python/tk_houdini_mantranode/handler.py
+++ b/python/tk_houdini_mantranode/handler.py
@@ -240,6 +240,25 @@ class TkMantraNodeHandler(object):
             app.log_debug("Converted: Tk Mantra node '%s' to Mantra node."
                 % (tk_mantra_node_name,))
 
+    @classmethod
+    def get_all_tk_mantra_nodes(cls):
+        """
+        Returns a list of all tk-houdini-alembic node instances in the current
+        session.
+        """
+
+        # get all instances of tk mantra nodes
+        tk_node_type = TkMantraNodeHandler.TK_MANTRA_NODE_TYPE
+        return hou.nodeType(hou.ropNodeTypeCategory(), tk_node_type).instances()
+
+    @classmethod
+    def get_output_path(cls, node):
+        """
+        Returns the evaluated output path for the supplied node.
+        """
+
+        output_parm = node.parm(cls.NODE_OUTPUT_PATH_PARM)
+        return output_parm.unexpandedString()
 
     ############################################################################
     # Instance methods

--- a/python/tk_houdini_mantranode/handler.py
+++ b/python/tk_houdini_mantranode/handler.py
@@ -243,7 +243,7 @@ class TkMantraNodeHandler(object):
     @classmethod
     def get_all_tk_mantra_nodes(cls):
         """
-        Returns a list of all tk-houdini-alembic node instances in the current
+        Returns a list of all tk-houdini-mantranode instances in the current
         session.
         """
 


### PR DESCRIPTION
Adds `get_nodes()` and `get_output_path(node)` methods to the app. This allows apps like publisher to ask the installed `tk-houdini-mantranode` app for information that it knows how to get. This avoids some of the not-so-great code in publish1 where it was relying on internal knowledge of the mantranode app to collect items for publish. 