### PR TITLE
SG-7360: Fixes a parm type change introduced in recent 16.5.x releases of Houdini.

### DIFF
--- a/python/tk_houdini_mantranode/handler.py
+++ b/python/tk_houdini_mantranode/handler.py
@@ -797,7 +797,7 @@ def _copy_parm_values(source_node, target_node, excludes=None):
                 try:
                     target_parm.set(source_parm.eval())
                 except TypeError:
-                    # The pre- and post-script type comboboxes changed in sometime around
+                    # The pre- and post-script type comboboxes changed sometime around
                     # 16.5.439 to being string type parms that take the name of the language
                     # (hscript or python) instead of an integer index of the combobox item
                     # that's selected. To support both, we try the old way (which is how our

--- a/python/tk_houdini_mantranode/handler.py
+++ b/python/tk_houdini_mantranode/handler.py
@@ -794,8 +794,21 @@ def _copy_parm_values(source_node, target_node, excludes=None):
                 target_parm.set(source_parm.unexpandedString())
             # copy the evaluated value
             else:
-                target_parm.set(source_parm.eval())
-
+                try:
+                    target_parm.set(source_parm.eval())
+                except TypeError:
+                    # The pre- and post-script type comboboxes changed in sometime around
+                    # 16.5.439 to being string type parms that take the name of the language
+                    # (hscript or python) instead of an integer index of the combobox item
+                    # that's selected. To support both, we try the old way (which is how our
+                    # otl is setup to work), and if that fails we then fall back on mapping
+                    # the integer index from our otl's parm over to the string language name
+                    # that the mantra node is expecting.
+                    if source_parm.name().startswith("lpre") or source_parm.name().startswith("lpost"):
+                        value_map = ["hscript", "python"]
+                        target_parm.set(value_map[source_parm.eval()])
+                    else:
+                        raise
 
 def _get_extra_plane_numbers(node):
     """Return a list of aov plane nubmers.


### PR DESCRIPTION
Our OTL's pre- and post-script language comboboxes return integer indexes, while newer versions of Houdini expect a string of the name of the language being used (either hscript or python). We try the old way, by just giving the mantra node the value from our otl's matching parm, and if that raises a TypeError we fall back on mapping our index to the expected name of the language in string form.